### PR TITLE
Ignore regional settings and enforce '.' as decimal separator for num…

### DIFF
--- a/cefHtmlSnapshot.dpr
+++ b/cefHtmlSnapshot.dpr
@@ -124,6 +124,8 @@ end;
 var
    parameters : TSnapshotParameters;
 begin
+   FormatSettings.DecimalSeparator := '.';
+
    if (ParamCount > 0) and (Copy(ParamStr(1), 1, 6) = '--type') then begin
       RunAsSubProcess;
       Exit;


### PR DESCRIPTION
…eric parameters on the command-line